### PR TITLE
fix(summary): prevent redundant age-level updates

### DIFF
--- a/src/components/SummaryPanel.tsx
+++ b/src/components/SummaryPanel.tsx
@@ -57,8 +57,10 @@ export default function SummaryPanel({ text, title }: SummaryPanelProps) {
 
   const handleAgeLevelChange = (values: number[]) => {
     const newLevel = getNearestAgeLevel(values[0]);
-    setAgeLevel(newLevel);
-    fetchSummary(newLevel);
+    if (newLevel !== ageLevel) {
+      setAgeLevel(newLevel);
+      fetchSummary(newLevel);
+    }
   };
 
   const currentLevel = ageLevels[ageLevel as keyof typeof ageLevels];


### PR DESCRIPTION
Previously handleAgeLevelChange always updated state and fetched the summary even when the computed level matched the current ageLevel, which could trigger unnecessary re-renders and network requests.

Now the handler checks if the new level differs before calling setAgeLevel and fetchSummary. Also ensure newline at EOF.