### PR TITLE
fix(search): skip empty query

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,7 +37,10 @@ export default function Home() {
     setLoading(true);
     setError(null);
     setArticle(null);
-
+    if (query.trim() === "") {
+      setLoading(false);
+      return;
+    }
     // Track search in localStorage
     const lastSearches = JSON.parse(localStorage.getItem("last-searches") || "[]");
     lastSearches.unshift(query);


### PR DESCRIPTION
Previously submitting an empty search query set loading and continued with the search flow, causing unnecessary state updates and potential network activity.

Now the handler early-returns when query.trim() is empty, sets loading to false, and avoids proceeding with localStorage updates or fetch. Also ensure newline at end of file.

This prevents that one error from popping up