### PR TITLE
refactor(summary): use discrete proficiency levels

### DIFF
--- a/src/app/api/summarize/route.ts
+++ b/src/app/api/summarize/route.ts
@@ -14,13 +14,13 @@ export async function POST(request: NextRequest) {
     // Create age-appropriate prompt
     let prompt = "";
     switch (ageLevel) {
-      case 12:
+      case 1:
         prompt = `Explain this topic in simple, fun language for a 12-year-old. Use everyday examples and avoid complex jargon:\n\n${text}`;
         break;
-      case 20:
+      case 2:
         prompt = `Explain this topic clearly for a college student. Include key concepts and context:\n\n${text}`;
         break;
-      case 40:
+      case 3:
         prompt = `Provide a comprehensive, professional explanation of this topic with nuanced details:\n\n${text}`;
         break;
       default:
@@ -54,9 +54,9 @@ function generateMockSummary(text: string, ageLevel: number): string {
   let summary = sentences.slice(0, numSentences).join(". ") + ".";
   
   // Add age-appropriate prefix
-  if (ageLevel === 12) {
+  if (ageLevel === 1) {
     summary = "🎯 In simple terms: " + summary;
-  } else if (ageLevel === 20) {
+  } else if (ageLevel === 2) {
     summary = "📚 College level: " + summary;
   } else {
     summary = "🎓 Professional summary: " + summary;

--- a/src/components/SummaryPanel.tsx
+++ b/src/components/SummaryPanel.tsx
@@ -115,7 +115,7 @@ export default function SummaryPanel({ text, title }: SummaryPanelProps) {
 
         <div className="mt-6 p-4 bg-blue-50 dark:bg-blue-950 rounded-lg">
           <p className="text-sm text-muted-foreground">
-            💡 <strong>TL;DR:</strong> This is a {ageLevel}-year-old level explanation of <strong>{title}</strong>.
+            💡 <strong>TL;DR:</strong> This is a {currentLevel.label} level explanation of <strong>{title}</strong>.
             Adjust the slider above to see it explained differently!
           </p>
         </div>


### PR DESCRIPTION
Replace age-based codes (12, 20, 40) with discrete levels (1, 2, 3) in the API route and mock summary generator. Update SummaryPanel to display the currentLevel.label instead of a numeric age. Add newline at end of file for consistency.