### PR TITLE
fix(search): append 'finance' to srsearch

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -127,7 +127,7 @@ Non-finance topics include: history, science, sports, entertainment, technology 
     searchUrl.searchParams.set("action", "query");
     searchUrl.searchParams.set("format", "json");
     searchUrl.searchParams.set("list", "search");
-    searchUrl.searchParams.set("srsearch", query);
+    searchUrl.searchParams.set("srsearch", query + " finance");
     searchUrl.searchParams.set("origin", "*");
 
     const searchResponse = await fetch(searchUrl.toString());


### PR DESCRIPTION
Ensure search queries target finance-related results by appending "finance" to the srsearch parameter sent to the external API.

Also add a missing newline at end of file.