### PR TITLE
feat(encarta-logo): clear search when logo clicked

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -84,7 +84,7 @@ function HomeContent() {
         <header className="pt-8 pb-6 px-4">
           <div className="container mx-auto">
             <div className="flex justify-center mb-6">
-              <EncartaLogo />
+              <EncartaLogo handleSearch={handleSearch} />
             </div>
             
             {/* Navigation Tabs */}

--- a/src/components/EncartaLogo.tsx
+++ b/src/components/EncartaLogo.tsx
@@ -3,22 +3,14 @@
 import { motion } from "framer-motion";
 import Link from "next/link";
 
-export default function EncartaLogo() {
+export default function EncartaLogo({ handleSearch }: { handleSearch: (query: string) => void }) {
 
-  const handleLogoClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    console.log("🏠 Logo clicked - navigating to home");
-
-    // Force a clean navigation to home page without any search params
-    window.location.href = "/";
-  };
 
   return (
     <Link
       href="/"
       className="flex items-center gap-4"
-      onClick={handleLogoClick}
+      onClick={(e) => handleSearch("")}
     >
       <motion.div
         initial={{ scale: 0.8, opacity: 0 }}


### PR DESCRIPTION
Pass handleSearch from the page into EncartaLogo and invoke it with an empty string on click. This replaces the previous behavior that prevented default navigation and forced a hard redirect to "/", allowing the app to clear search state while preserving SPA navigation.