### PR TITLE
style: reserve scrollbar gutter and add EOF newline

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,6 +132,8 @@
   body {
     @apply bg-background text-foreground;
     font-family: 'MS Sans Serif', Arial, sans-serif;
+    overflow-y: scroll;
+    scrollbar-gutter: stable;
   }
   
   .encarta-bg {


### PR DESCRIPTION
Force vertical scrollbar to remain visible and reserve scrollbar gutter to prevent layout shift when pages toggle scrollbars. Also add missing newline at end of src/app/globals.css.